### PR TITLE
Allow tsv extension and sniff csv dialect

### DIFF
--- a/kifield/__main__.py
+++ b/kifield/__main__.py
@@ -55,7 +55,7 @@ def main():
         '-x',
         nargs='+',
         type=str,
-        metavar='file.[xlsx|csv|sch|lib|dcm]',
+        metavar='file.[xlsx|csv|tsv|sch|lib|dcm]',
         help='''Extract field values from one or more spreadsheet or
             schematic files.''')
     parser.add_argument(
@@ -63,7 +63,7 @@ def main():
         '-i',
         nargs='+',
         type=str,
-        metavar='file.[xlsx|csv|sch|lib|dcm]',
+        metavar='file.[xlsx|csv|tsv|sch|lib|dcm]',
         help='''Insert extracted field values into one or more schematic
             or spreadsheet files.''')
     parser.add_argument('--overwrite',


### PR DESCRIPTION
This allows you to use a .tsv extension and will default to a tab-seperator if you write to a new `.tsv`. All existing csv/tsv files are now sniffed to determine their dialect (extension is irrelevant in that case). 