### PR TITLE
Set default encoding to utf8

### DIFF
--- a/kifield/kifield.py
+++ b/kifield/kifield.py
@@ -46,6 +46,9 @@ from .schlib import SchLib
 from .dcm import Dcm, Component
 import pdb
 
+reload(sys)
+sys.setdefaultencoding('utf8')
+
 logger = logging.getLogger('kifield')
 
 USING_PYTHON2 = (sys.version_info.major == 2)


### PR DESCRIPTION
This fixes #1. I played around a while trying to set `encoding='utf-8'` in all the csv `reader` and `writer` constructors and `open` calls and using the unicodecsv module. Nothing seemed to work.  

I understand this is essentially a hack but it does work. I believe it's a no-op in Python 3.

https://stackoverflow.com/questions/3828723/why-should-we-not-use-sys-setdefaultencodingutf-8-in-a-py-script