### PR TITLE
Increase the csv sniff size to the whole file

### DIFF
--- a/kifield/kifield.py
+++ b/kifield/kifield.py
@@ -125,7 +125,7 @@ def csvfile_to_wb(csv_filename):
         'Converting CSV file {} into an XLSX workbook.'.format(csv_filename))
 
     with open(csv_filename) as csv_file:
-        dialect = csv.Sniffer().sniff(csv_file.read(1024))
+        dialect = csv.Sniffer().sniff(csv_file.read())
         if USING_PYTHON2:
             for attr in dir(dialect):
                 a = getattr(dialect, attr)


### PR DESCRIPTION
This fixes #17 by always passing the whole file to the CSV sniffer.
