### PR TITLE
line 525: Fix sheet_file assignment to work for schematics outside current directory

### DIFF
--- a/kifield/kifield.py
+++ b/kifield/kifield.py
@@ -522,7 +522,8 @@ def extract_part_fields_from_sch(filename, inc_field_names=None, exc_field_names
         for sheet in sch.sheets:
             for field in sheet.fields:
                 if field['id'] == 'F1':
-                    sheet_file = unquote(field['value'])
+                    #sheet_file = unquote(field['value'])
+                    sheet_file = os.path.join(os.path.dirname(filename),unquote(field['value']))
                     part_fields_dict.update(extract_part_fields_from_sch(sheet_file, inc_field_names, exc_field_names, recurse, depth+1))
                     break
 

--- a/kifield/kifield.py
+++ b/kifield/kifield.py
@@ -522,7 +522,6 @@ def extract_part_fields_from_sch(filename, inc_field_names=None, exc_field_names
         for sheet in sch.sheets:
             for field in sheet.fields:
                 if field['id'] == 'F1':
-                    #sheet_file = unquote(field['value'])
                     sheet_file = os.path.join(os.path.dirname(filename),unquote(field['value']))
                     part_fields_dict.update(extract_part_fields_from_sch(sheet_file, inc_field_names, exc_field_names, recurse, depth+1))
                     break


### PR DESCRIPTION
I've followed the directions from the "Contributing" file, but:
- I don't know how to make a test for this change.
- I set up the virtualenv and ran the "python setup.py develop" -- which I believe installs the proper dependencies?
- flake8 kifield/kifield.py already fails in various places, none of which are on line 525
- python setup.py tests runs 0 tests, not sure why
- tox is unable to find python3.4, python3.6 and pypy

I'm happy to work these problems out. I use KiField very often and would be happy to support.